### PR TITLE
fix simple_maze map path

### DIFF
--- a/maps/simple_maze.yaml
+++ b/maps/simple_maze.yaml
@@ -1,4 +1,4 @@
-image: /home/jessica/simple_maze.pgm
+image: ./simple_maze.pgm
 resolution: 0.050000
 origin: [-10.000000, -10.000000, 0.000000]
 negate: 0


### PR DESCRIPTION
Fixes the hard-coded path. This would allow launch of rviz with the default map